### PR TITLE
Fix link to KUKSA logo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # KUKSA Python SDK
-![kuksa.val Logo](https://github.com/eclipse-kuksa/kuksa-python-sdk/blob/main/docs/pictures/logo.png)
+![kuksa.val Logo](https://raw.githubusercontent.com/eclipse-kuksa/kuksa-python-sdk/main/docs/pictures/logo.png)
 
 KUKSA Python Client and SDK is a part of the open source project [Eclipse KUKSA](https://www.eclipse.org/kuksa/).
 More about Eclipse KUKSA can be found in the [repository](https://github.com/eclipse/kuksa.val).


### PR DESCRIPTION
The logo in Pypi is broken, as the link was pointing to a Github page instead of an image directly.

See: https://pypi.org/project/kuksa-client/ (and when clicking "show image" on the roken link, you see the CDN complaining that a wrong content type is delivered)

 This can also be seen when using .md preview in Visual Studio code: it is also broken there. Only GH WebUI was clever enough to fix this.

With the updated link it should work everywhere.