### PR TITLE
Rename checkConnection

### DIFF
--- a/kuksa-client/kuksa_client/__init__.py
+++ b/kuksa-client/kuksa_client/__init__.py
@@ -37,8 +37,23 @@ class KuksaClientThread(threading.Thread):
         self.backend = cli_backend.Backend.from_config(config)
         self.loop = None
 
-    def checkConnection(self):
-        return self.backend.checkConnection()
+    # PEP 702 deprecated decorator available first in Python 3.13
+    def checkConnection(self) -> bool:
+        """
+        Check if thread has established a connection to the broker/server.
+        Note that this method does not indicate the current state of the connection,
+        This method may return True even if the broker/server currently is not reachable.
+        Deprecated - Use connection_established() instead"
+        """
+        return self.connection_established()
+
+    def connection_established(self) -> bool:
+        """
+        Check if thread has established a connection to the broker/server.
+        Note that this method does not indicate the current state of the connection,
+        This method may return True even if the broker/server currently is not reachable.
+        """
+        return self.backend.connection_established()
 
     def stop(self):
         self.backend.stop()

--- a/kuksa-client/kuksa_client/cli_backend/grpc.py
+++ b/kuksa-client/kuksa_client/cli_backend/grpc.py
@@ -69,7 +69,7 @@ class Backend(cli_backend.Backend):
                 self.token = str(self.token_or_tokenfile)
         else:
             self.token = ""
-        self.grpcConnected = False
+        self.grpc_connection_established = False
 
         self.sendMsgQueue = queue.Queue()
         self.run = False
@@ -80,11 +80,11 @@ class Backend(cli_backend.Backend):
             "metadata": (kuksa_client.grpc.Field.METADATA, kuksa_client.grpc.View.METADATA),
         }
 
-    # Function to check connection status
-    def checkConnection(self):
-        if self.grpcConnected:
-            return True
-        return False
+    def connection_established(self) -> bool:
+        """
+        Function to check connection status
+        """
+        return self.grpc_connection_established
 
     # Function to stop the communication
     def stop(self):
@@ -215,10 +215,10 @@ class Backend(cli_backend.Backend):
 
     # Async function to handle the gRPC calls
     async def _grpcHandler(self, vss_client: kuksa_client.grpc.aio.VSSClient):
-        self.grpcConnected = True
         self.run = True
         subscriber_manager = kuksa_client.grpc.aio.SubscriberManager(
             vss_client)
+        self.grpc_connection_established = True
         while self.run:
             try:
                 (call, requestArgs, responseQueue) = self.sendMsgQueue.get_nowait()
@@ -257,7 +257,7 @@ class Backend(cli_backend.Backend):
                 responseQueue.put(
                     (None, {"error": "ValueError in casting the value."}))
 
-        self.grpcConnected = False
+        self.grpc_connection_established = False
 
     # Update VSS Tree Entry
     def updateVSSTree(self, jsonStr, timeout=5):

--- a/kuksa-client/kuksa_client/cli_backend/ws.py
+++ b/kuksa-client/kuksa_client/cli_backend/ws.py
@@ -35,7 +35,7 @@ from kuksa_client import cli_backend
 class Backend(cli_backend.Backend):
     def __init__(self, config):
         super().__init__(config)
-        self.wsConnected = False
+        self.ws_connection_established = False
         self.subprotocol = None
         self.token = None
         self.subscriptionCallbacks = {}
@@ -72,7 +72,7 @@ class Backend(cli_backend.Backend):
                 return
 
     async def _msgHandler(self, webSocket):
-        self.wsConnected = True
+        self.ws_connection_established = True
         self.run = True
         recv = asyncio.Task(self._receiver_handler(webSocket))
         send = asyncio.Task(self._sender_handler(webSocket))
@@ -111,7 +111,7 @@ class Backend(cli_backend.Backend):
 
     # Function to stop the communication
     def stop(self):
-        self.wsConnected = False
+        self.ws_connection_established = False
         self.run = False
         print("Server disconnected.")
 
@@ -284,9 +284,11 @@ class Backend(cli_backend.Backend):
 
         return res
 
-    # Function to check connection
-    def checkConnection(self):
-        return self.wsConnected
+    def connection_established(self) -> bool:
+        """
+        Function to check connection
+        """
+        return self.ws_connection_established
 
     async def connect(self, _=None):
         subprotocols = ["VISSv2"]


### PR DESCRIPTION
The previous method name could give the impression that the connection actually would be checked when the method was called.

What the method actually does it just to report the flag that is set when the initial connection has been established and the client is ready to receive data from the broker/server. That should hopefully be more clear after the change of name.

Old name kept on "top level" to not introduce any backward incompatible changes.

Fixes https://github.com/eclipse/kuksa.val/issues/523