### PR TITLE
Updating Databroker submodule and Fix build error

### DIFF
--- a/.github/workflows/kuksa-client.yml
+++ b/.github/workflows/kuksa-client.yml
@@ -143,9 +143,10 @@ jobs:
       - name: Install dependencies with pip
         run: |
           cd kuksa-client
-          python3 -m proto
-          pip install -r requirements.txt -e .
+          pip install -r requirements.txt
           pip install -r test-requirements.txt
+          python3 -m proto
+          pip install -e .
       - name: Run tests
         run: |
           cd kuksa-client

--- a/kuksa-client/requirements.txt
+++ b/kuksa-client/requirements.txt
@@ -4,29 +4,29 @@
 #
 #    pip-compile setup.cfg
 #
-attrs==23.2.0
+attrs==24.2.0
     # via cmd2
 cmd2==1.5.0
     # via kuksa_client (setup.cfg)
 colorama==0.4.6
     # via cmd2
-grpcio==1.66.2
+grpcio==1.67.1
     # via grpcio-tools
-grpcio-tools==1.66.2
+grpcio-tools==1.67.1
     # via kuksa_client (setup.cfg)
-jsonpath-ng==1.6.1
+jsonpath-ng==1.7.0
     # via kuksa_client (setup.cfg)
 ply==3.11
     # via jsonpath-ng
-protobuf==5.27.2
+protobuf==5.28.3
     # via grpcio-tools
 pygments==2.18.0
     # via kuksa_client (setup.cfg)
-pyperclip==1.8.2
+pyperclip==1.9.0
     # via cmd2
 wcwidth==0.2.13
     # via cmd2
-websockets==12.0
+websockets==13.1
     # via kuksa_client (setup.cfg)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/kuksa-client/test-requirements.txt
+++ b/kuksa-client/test-requirements.txt
@@ -4,75 +4,75 @@
 #
 #    pip-compile --extra=test --output-file=test-requirements.txt setup.cfg
 #
-astroid==3.2.2
+astroid==3.3.5
     # via pylint
-attrs==23.2.0
+attrs==24.2.0
     # via cmd2
 cmd2==1.5.0
     # via kuksa_client (setup.cfg)
 colorama==0.4.6
     # via cmd2
-coverage[toml]==7.5.3
+coverage[toml]==7.6.4
     # via pytest-cov
-dill==0.3.8
+dill==0.3.9
     # via pylint
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
-grpcio==1.66.2
+grpcio==1.67.1
     # via grpcio-tools
-grpcio-tools==1.66.2
+grpcio-tools==1.67.1
     # via kuksa_client (setup.cfg)
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via pylint
-jsonpath-ng==1.6.1
+jsonpath-ng==1.7.0
     # via kuksa_client (setup.cfg)
 mccabe==0.7.0
     # via pylint
 packaging==24.1
     # via pytest
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via pylint
 pluggy==1.5.0
     # via pytest
 ply==3.11
     # via jsonpath-ng
-protobuf==5.27.2
+protobuf==5.28.3
     # via grpcio-tools
 pygments==2.18.0
     # via kuksa_client (setup.cfg)
-pylint==3.2.3
+pylint==3.3.1
     # via kuksa_client (setup.cfg)
-pyperclip==1.8.2
+pyperclip==1.9.0
     # via cmd2
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   kuksa_client (setup.cfg)
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
     #   pytest-timeout
-pytest-asyncio==0.23.7
+pytest-asyncio==0.24.0
     # via kuksa_client (setup.cfg)
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via kuksa_client (setup.cfg)
 pytest-mock==3.14.0
     # via kuksa_client (setup.cfg)
 pytest-timeout==2.3.1
     # via kuksa_client (setup.cfg)
-tomli==2.0.1
+tomli==2.0.2
     # via
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.5
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via astroid
 wcwidth==0.2.13
     # via cmd2
-websockets==12.0
+websockets==13.1
     # via kuksa_client (setup.cfg)
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
To solve build error on main. Updating submodule reference should not have impact, but on the other hand should not matter.

What I think was root cause:

- proto files were generated before we installed requirement.txt, using a newer proto than in lock file
- that gave problems in next step as grpcio was too old
- 