### PR TITLE
Make sure v2 used only when possible

### DIFF
--- a/kuksa-client/tests/conftest.py
+++ b/kuksa-client/tests/conftest.py
@@ -53,7 +53,7 @@ def val_servicer_v2_fixture(mocker):
     return servicer_v2
 
 
-@pytest_asyncio.fixture(name="val_server", scope="function")
+@pytest_asyncio.fixture(name="mocked_databroker", scope="function")
 async def val_server_fixture(unused_tcp_port, val_servicer_v1, val_servicer_v2):
     server = grpc.aio.server()
     val_v1.add_VALServicer_to_server(val_servicer_v1, server)
@@ -66,7 +66,7 @@ async def val_server_fixture(unused_tcp_port, val_servicer_v1, val_servicer_v2):
         await server.stop(grace=2.0)
 
 
-@pytest_asyncio.fixture(name="secure_val_server", scope="function")
+@pytest_asyncio.fixture(name="secure_mocked_databroker", scope="function")
 async def secure_val_server_fixture(
     unused_tcp_port, resources_path, val_servicer_v1, val_servicer_v2
 ):

--- a/kuksa-client/tests/test_grpc.py
+++ b/kuksa-client/tests/test_grpc.py
@@ -477,7 +477,7 @@ class TestEntryUpdate:
 @pytest.mark.asyncio
 class TestVSSClient:
 
-    @pytest.mark.usefixtures("secure_val_server")
+    @pytest.mark.usefixtures("secure_mocked_databroker")
     async def test_secure_connection(
         self, unused_tcp_port, resources_path, val_servicer_v1
     ):
@@ -745,7 +745,7 @@ class TestVSSClient:
             'Vehicle.Chassis.Height': Metadata(entry_type=EntryType.ATTRIBUTE),
         }
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_get_some_entries(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.Get.return_value = val_v1.GetResponse(
             entries=[
@@ -948,7 +948,7 @@ class TestVSSClient:
                 ).entries
             )
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_get_no_entries_requested(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.Get.side_effect = generate_error(
             grpc.StatusCode.INVALID_ARGUMENT, "No datapoints requested"
@@ -964,7 +964,7 @@ class TestVSSClient:
             }, errors=[]).args
             assert val_servicer_v1.Get.call_args[0][0] == val_v1.GetRequest()
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_get_unset_entries(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.Get.return_value = val_v1.GetResponse(
             entries=[
@@ -982,7 +982,7 @@ class TestVSSClient:
         assert entries == [DataEntry('Vehicle.Speed'), DataEntry(
             'Vehicle.ADAS.ABS.IsActive')]
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_get_nonexistent_entries(self, unused_tcp_port, val_servicer_v1):
         error = types_v1.Error(
             code=404, reason="not_found", message="Does.Not.Exist not found"
@@ -998,7 +998,7 @@ class TestVSSClient:
                                  View.CURRENT_VALUE, (Field.VALUE,)),
                 ))
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_set_some_updates_v1(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.Get.return_value = val_v1.GetResponse(
             entries=(
@@ -1234,7 +1234,7 @@ class TestVSSClient:
                 ).updates
             )
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_set_some_updates_v2(
         self, unused_tcp_port, val_servicer_v2, val_servicer_v1
     ):
@@ -1313,7 +1313,7 @@ class TestVSSClient:
             ):
                 assert actual_request == expected_request
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_set_some_updates_v2_target(
         self, unused_tcp_port, val_servicer_v2, val_servicer_v1
     ):
@@ -1358,7 +1358,7 @@ class TestVSSClient:
             assert val_servicer_v1.Get.call_count == 1
             assert val_servicer_v2.PublishValue.call_count == 0
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_set_no_updates_provided(
         self, unused_tcp_port, val_servicer_v1, val_servicer_v2
     ):
@@ -1399,7 +1399,7 @@ class TestVSSClient:
             assert val_servicer_v1.Get.call_count == 0
             assert val_servicer_v2.PublishValue.call_count == 0
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_set_nonexistent_entries_v1(self, unused_tcp_port, val_servicer_v1):
         error = types_v1.Error(
             code=404, reason="not_found", message="Does.Not.Exist not found"
@@ -1445,7 +1445,7 @@ class TestVSSClient:
             )  # Get should'nt have been called again
             assert val_servicer_v1.Set.call_count == 1
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_set_nonexistent_entries_v2(
         self, unused_tcp_port, val_servicer_v2, val_servicer_v1
     ):
@@ -1496,7 +1496,7 @@ class TestVSSClient:
             )  # Get should'nt have been called again
             assert val_servicer_v2.PublishValue.call_count == 1
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_authorize_successful(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.GetServerInfo.return_value = val_v1.GetServerInfoResponse(
             name="test_server", version="1.2.3"
@@ -1531,7 +1531,7 @@ class TestVSSClient:
             assert client.authorization_header == bearer
             assert success == "Authenticated"
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_authorize_unsuccessful(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.GetServerInfo.side_effect = generate_error(
             grpc.StatusCode.UNAUTHENTICATED,
@@ -1542,7 +1542,7 @@ class TestVSSClient:
                 await client.authorize(token='')
             assert client.authorization_header is None
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_subscribe_some_entries_v1(
         self, mocker, unused_tcp_port, val_servicer_v1
     ):
@@ -1734,7 +1734,7 @@ class TestVSSClient:
                 ],
             ]
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_subscribe_some_entries_v2(
         self, mocker, unused_tcp_port, val_servicer_v2
     ):
@@ -1846,7 +1846,7 @@ class TestVSSClient:
                 ],
             ]
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_subscribe_some_entries_v2_target(
         self, mocker, unused_tcp_port, val_servicer_v2
     ):
@@ -1879,7 +1879,7 @@ class TestVSSClient:
 
             assert not actual_responses
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_subscribe_no_entries_requested(
         self, mocker, unused_tcp_port, val_servicer_v1, val_servicer_v2
     ):
@@ -1903,7 +1903,7 @@ class TestVSSClient:
                 async for _ in client.subscribe(entries=(), try_v2=True):
                     pass
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_subscribe_nonexistent_entries(
         self, mocker, unused_tcp_port, val_servicer_v1, val_servicer_v2
     ):
@@ -1939,7 +1939,7 @@ class TestVSSClient:
                 ):
                     pass
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_get_server_info(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.GetServerInfo.return_value = val_v1.GetServerInfoResponse(
             name="test_server", version="1.2.3"
@@ -1949,7 +1949,7 @@ class TestVSSClient:
             assert server_info == ServerInfo(
                 name='test_server', version='1.2.3')
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_get_server_info_unavailable(self, unused_tcp_port, val_servicer_v1):
         val_servicer_v1.GetServerInfo.side_effect = generate_error(
             grpc.StatusCode.UNAVAILABLE, "Unavailable"
@@ -1962,7 +1962,7 @@ class TestVSSClient:
 @pytest.mark.asyncio
 class TestSubscriberManager:
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_add_subscriber_v1(self, mocker, unused_tcp_port, val_servicer_v1):
         async with VSSClient('127.0.0.1', unused_tcp_port, ensure_startup_connection=False) as client:
             subscriber_manager = SubscriberManager(client)
@@ -2047,7 +2047,7 @@ class TestSubscriberManager:
                 ],
             ]
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_remove_subscriber_v1(self, mocker, unused_tcp_port, val_servicer_v1):
         async with VSSClient(
             "127.0.0.1", unused_tcp_port, ensure_startup_connection=False
@@ -2095,7 +2095,7 @@ class TestSubscriberManager:
                 exc_info.value.args[0] == f"Could not find subscription {str(sub_uid)}"
             )
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_add_subscriber_v2(self, mocker, unused_tcp_port, val_servicer_v2):
         _entries: Dict[str, types_v2.Datapoint] = {
             "Vehicle.Speed": types_v2.Datapoint(
@@ -2165,7 +2165,7 @@ class TestSubscriberManager:
                 ],
             ]
 
-    @pytest.mark.usefixtures("val_server")
+    @pytest.mark.usefixtures("mocked_databroker")
     async def test_remove_subscriber_v2(self, mocker, unused_tcp_port, val_servicer_v2):
         async with VSSClient(
             "127.0.0.1", unused_tcp_port, ensure_startup_connection=False


### PR DESCRIPTION
This PR tries to solve some problems

- Do not try to use `v2` by default for subscribe/set, as it does not work for target values
- Add an extra check if using v2 - to give errors if we try to set anything else than actual value.

No extra testcases added for the non-async use-case as we do not have any test framework there AFIAK