### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/kuksa-client.yml
+++ b/.github/workflows/kuksa-client.yml
@@ -140,8 +140,7 @@ jobs:
       - name: Install dependencies with pip
         run: |
           cd kuksa-client
-          pip install -r requirements.txt
-          pip install -r test-requirements.txt
+          pip install -r requirements.txt -r test-requirements.txt
           python3 -m proto
           pip install -e .
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Github Release and PyPi Publish
+
+on:
+  workflow_dispatch:
+  push:
+   tags:
+     - "*.*.*"
+
+jobs:
+  build:
+    name: Build distribution and publish 🐍 to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/kuksa-client
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - name: Checkout kuksa-python-sdk
+      uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Install dependencies with pip
+      run: |
+        cd kuksa-client
+        pip install -r requirements.txt
+        pip install -e .
+    - name: Install pypa/build
+      run: pip install build --user
+    - name: Build for PyPI
+      run: |
+        cd kuksa-client
+        python3 -m build
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: kuksa-client/dist
+    - name: Create draft release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: true
+        name: KUKSA Python SDK ${{ github.ref_name }}

--- a/kuksa-client/pyproject.toml
+++ b/kuksa-client/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    # Make sure to use the same version criteria in pyproject.toml and update requirements.txt after changing
-    "grpcio-tools~=1.68",
+    # Make sure to use the same exact version criteria in setup.cfg and update requirements.txt after changing
+    "grpcio-tools==1.68.0",
     "setuptools>=42",
     "setuptools-git-versioning",
     "wheel",

--- a/kuksa-client/setup.cfg
+++ b/kuksa-client/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     cmd2 >= 1.4, <2.0
     pygments >= 2.15
     # Make sure to use the same version criteria in pyproject.toml and update requirements.txt after changing
-    grpcio-tools ~= 1.68
+    grpcio-tools == 1.68.0
     jsonpath-ng >= 1.5.3
 packages = find:
 

--- a/kuksa-client/test-requirements.txt
+++ b/kuksa-client/test-requirements.txt
@@ -12,15 +12,15 @@ cmd2==1.5.0
     # via kuksa_client (setup.cfg)
 colorama==0.4.6
     # via cmd2
-coverage[toml]==7.6.4
+coverage[toml]==7.6.7
     # via pytest-cov
 dill==0.3.9
     # via pylint
 exceptiongroup==1.2.2
     # via pytest
-grpcio==1.67.1
+grpcio==1.68.0
     # via grpcio-tools
-grpcio-tools==1.67.1
+grpcio-tools==1.68.0
     # via kuksa_client (setup.cfg)
 iniconfig==2.0.0
     # via pytest
@@ -30,7 +30,7 @@ jsonpath-ng==1.7.0
     # via kuksa_client (setup.cfg)
 mccabe==0.7.0
     # via pylint
-packaging==24.1
+packaging==24.2
     # via pytest
 platformdirs==4.3.6
     # via pylint
@@ -61,7 +61,7 @@ pytest-mock==3.14.0
     # via kuksa_client (setup.cfg)
 pytest-timeout==2.3.1
     # via kuksa_client (setup.cfg)
-tomli==2.0.2
+tomli==2.1.0
     # via
     #   coverage
     #   pylint
@@ -72,7 +72,7 @@ typing-extensions==4.12.2
     # via astroid
 wcwidth==0.2.13
     # via cmd2
-websockets==13.1
+websockets==14.1
     # via kuksa_client (setup.cfg)
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This removes most manual steps for creating a PyPI-release, and means that anyone with write access to this repo can create a pypi-release. The reason this works is because I (as PypI owner/maintainer) has added the workflow as a trusted workflow. For now I have also added my own workflow and have performed tests using it.

![image](https://github.com/user-attachments/assets/f311e499-7045-48c0-9896-a8697528f1cb)


Also updating dependencies due to broken dependency between protobuf and grpio-tools

Markdown error is due to error in submodule

See https://github.com/eclipse-kuksa/kuksa-python-sdk/wiki/Release-Process for some notes on how this will affect release process