### PR TITLE
Fix set_current_values using kuksa.val.v2 API

### DIFF
--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -1279,7 +1279,7 @@ class VSSClient(BaseVSSClient):
                     update, paths_with_required_type
                 )
                 try:
-                    resp = self.client_stub_v2.PublishValueRequest(req, **rpc_kwargs)
+                    resp = self.client_stub_v2.PublishValue(req, **rpc_kwargs)
                 except RpcError as exc:
                     if exc.code() == grpc.StatusCode.UNIMPLEMENTED:
                         logger.debug("v2 not available fall back to v1 instead")


### PR DESCRIPTION
`set_current_values` is mapped in kuksa.val.v2 API to call `PublishValueRequest`. But this is not existing as a callable method. The method is called just `PublishValue`.