### PR TITLE
fix: pin protobuf>=5.29.6,<6.0dev to prevent gencode/runtime version mismatch

### DIFF
--- a/kuksa-client/pyproject.toml
+++ b/kuksa-client/pyproject.toml
@@ -2,6 +2,8 @@
 requires = [
     # Make sure to use the same exact version criteria in setup.cfg and update requirements.txt after changing
     "grpcio-tools==1.68.0",
+    # Explicit protobuf pin matching setup.cfg to avoid gencode/runtime version mismatch. Fixes #54.
+    "protobuf>=5.29.6,<6.0dev",
     "setuptools>=77",
     "setuptools-git-versioning",
     "wheel",

--- a/kuksa-client/setup.cfg
+++ b/kuksa-client/setup.cfg
@@ -29,6 +29,11 @@ install_requires =
     pygments >= 2.15
     # Make sure to use the same version criteria in pyproject.toml and update requirements.txt after changing
     grpcio-tools == 1.68.0
+    # Explicit protobuf pin: grpcio-tools 1.68.0 resolves to protobuf 5.29.x; the
+    # generated _pb2 files must be loaded by a compatible runtime version.
+    # Without this constraint, pip may install a mismatched version and raise
+    # "Detected incompatible Protobuf Gencode/Runtime versions". Fixes #54.
+    protobuf >= 5.29.6, < 6.0dev
     jsonpath-ng >= 1.5.3
 packages = find:
 


### PR DESCRIPTION
## Problem

Fixes #54. Installing `kuksa-client` via `pip install kuksa-client` fails with:

```
RuntimeWarning: Detected incompatible Protobuf Gencode/Runtime versions
```

The root cause: `grpcio-tools==1.68.0` requires `protobuf>=5.26.1` but does not pin a maximum. `pip` may resolve to a protobuf version that is incompatible with the `.proto`-generated `_pb2.py` files included in the package. In the reported case, protobuf 5.27.3 was installed at build time and 5.29.x at runtime — the version check in `_pb2.py` fails.

## Fix

Add explicit `protobuf >= 5.29.6, < 6.0dev` constraint to:

- `setup.cfg` `install_requires` — ensures the runtime installs a compatible version
- `pyproject.toml` `build-system.requires` — ensures the build generates `_pb2.py` files with the same protobuf version

The `<6.0dev` upper bound follows the established `grpcio`/`grpcio-tools` pattern of excluding the next major (which has breaking generated code changes). The lower bound matches `grpcio-tools==1.68.0`'s resolved `protobuf==5.29.6`.

## No API changes

This is a dependency metadata fix only. No Python source files change.

---

*AI-assisted — authored with Claude, reviewed by Komada.*