### PR TITLE
Fix wildcard regression in subscribe_current_values on v2 (closes #53)

### DIFF
--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -1188,13 +1188,32 @@ class VSSClient(BaseVSSClient):
             ]):
                 for path, dp in updates.items():
                     print(f"Current value for {path} is now: {dp.value}")
+
+        Branch paths (e.g. ``['Vehicle']`` or ``['Vehicle.Cabin.*']``) are
+        accepted: if the v2 Subscribe RPC rejects a path with NOT_FOUND, the
+        paths are expanded via ListMetadata and the subscription is retried
+        with the resulting leaf signals. This restores the wildcard semantics
+        that v1 provided natively.
         """
+        paths = list(paths)
         try:
             logger.debug("Try to subscribe current values via v2")
-            for updates in self.v2_subscribe(paths, **rpc_kwargs):
-                yield {
-                    update.entry.path: update.entry.value for update in updates
-                }
+            try:
+                for updates in self.v2_subscribe(paths, **rpc_kwargs):
+                    yield {
+                        update.entry.path: update.entry.value for update in updates
+                    }
+            except VSSClientError as exc:
+                if exc.error["code"] != grpc.StatusCode.NOT_FOUND.value[0]:
+                    raise
+                logger.debug(
+                    "v2 Subscribe returned NOT_FOUND; expanding branch paths via ListMetadata"
+                )
+                expanded = self._expand_v2_branch_paths(paths, **rpc_kwargs)
+                for updates in self.v2_subscribe(expanded, **rpc_kwargs):
+                    yield {
+                        update.entry.path: update.entry.value for update in updates
+                    }
         except VSSClientError as exc:
             if exc.error["code"] != grpc.StatusCode.UNIMPLEMENTED.value[0]:
                 raise
@@ -1350,6 +1369,43 @@ class VSSClient(BaseVSSClient):
         elif signal_id.HasField("id") and signal_id.id in self.id_to_path_mapping:
             return self.id_to_path_mapping[signal_id.id]
         return "<unknown signal>"
+
+    def _expand_v2_branch_paths(
+        self, paths: Iterable[str], **rpc_kwargs
+    ) -> List[str]:
+        """Expand branch / wildcard paths into concrete leaf signals.
+
+        For each input path, calls ``ListMetadata(root=path)`` and returns
+        every signal path beneath that branch. Leaf paths pass through
+        (ListMetadata returns a single entry). Non-existent paths surface
+        as NOT_FOUND. Trailing ``.*`` suffixes are stripped before lookup.
+
+        Order is preserved and duplicates (from overlapping branches) are
+        removed. Used to restore v1-style wildcard semantics on top of the
+        v2 Subscribe RPC, which only accepts fully-qualified leaf paths.
+        """
+        rpc_kwargs["metadata"] = self.generate_metadata_header(
+            rpc_kwargs.get("metadata")
+        )
+        expanded: List[str] = []
+        for path in paths:
+            lookup = path[:-2] if path.endswith(".*") else path
+            req = self._prepare_v2_list_metadata_request(lookup)
+            try:
+                resp = self.client_stub_v2.ListMetadata(req, **rpc_kwargs)
+            except RpcError as exc:
+                raise VSSClientError.from_grpc_error(exc) from exc
+            if not resp.metadata:
+                raise VSSClientError(
+                    error={
+                        "code": grpc.StatusCode.NOT_FOUND.value[0],
+                        "reason": grpc.StatusCode.NOT_FOUND.value[1],
+                        "message": f"Path {path} not found on server",
+                    },
+                    errors=[],
+                )
+            expanded.extend(m.path for m in resp.metadata)
+        return list(dict.fromkeys(expanded))
 
     def ensure_id_mapping(self, paths: Iterable[str], **rpc_kwargs):
         for path in paths:

--- a/kuksa-client/kuksa_client/grpc/aio.py
+++ b/kuksa-client/kuksa_client/grpc/aio.py
@@ -303,13 +303,32 @@ class VSSClient(BaseVSSClient):
             ]):
                 for path, dp in updates.items():
                     print(f"Current value for {path} is now: {dp.value}")
+
+        Branch paths (e.g. ``['Vehicle']`` or ``['Vehicle.Cabin.*']``) are
+        accepted: if the v2 Subscribe RPC rejects a path with NOT_FOUND, the
+        paths are expanded via ListMetadata and the subscription is retried
+        with the resulting leaf signals. This restores the wildcard semantics
+        that v1 provided natively.
         """
+        paths = list(paths)
         try:
             logger.debug("Try to subscribe current values via v2")
-            async for updates in self.v2_subscribe(paths=paths, **rpc_kwargs):
-                yield {
-                    update.entry.path: update.entry.value for update in updates
-                }
+            try:
+                async for updates in self.v2_subscribe(paths=paths, **rpc_kwargs):
+                    yield {
+                        update.entry.path: update.entry.value for update in updates
+                    }
+            except VSSClientError as exc:
+                if exc.error["code"] != grpc.StatusCode.NOT_FOUND.value[0]:
+                    raise
+                logger.debug(
+                    "v2 Subscribe returned NOT_FOUND; expanding branch paths via ListMetadata"
+                )
+                expanded = await self._expand_v2_branch_paths(paths, **rpc_kwargs)
+                async for updates in self.v2_subscribe(paths=expanded, **rpc_kwargs):
+                    yield {
+                        update.entry.path: update.entry.value for update in updates
+                    }
         except VSSClientError as exc:
             if exc.error["code"] != grpc.StatusCode.UNIMPLEMENTED.value[0]:
                 raise
@@ -467,6 +486,43 @@ class VSSClient(BaseVSSClient):
         elif signal_id.HasField("id") and signal_id.id in self.id_to_path_mapping:
             return self.id_to_path_mapping[signal_id.id]
         return "<unknown signal>"
+
+    async def _expand_v2_branch_paths(
+        self, paths: Iterable[str], **rpc_kwargs
+    ) -> List[str]:
+        """Expand branch / wildcard paths into concrete leaf signals.
+
+        For each input path, calls ``ListMetadata(root=path)`` and returns
+        every signal path beneath that branch. Leaf paths pass through
+        (ListMetadata returns a single entry). Non-existent paths surface
+        as NOT_FOUND. Trailing ``.*`` suffixes are stripped before lookup.
+
+        Order is preserved and duplicates (from overlapping branches) are
+        removed. Used to restore v1-style wildcard semantics on top of the
+        v2 Subscribe RPC, which only accepts fully-qualified leaf paths.
+        """
+        rpc_kwargs["metadata"] = self.generate_metadata_header(
+            rpc_kwargs.get("metadata")
+        )
+        expanded: List[str] = []
+        for path in paths:
+            lookup = path[:-2] if path.endswith(".*") else path
+            req = self._prepare_v2_list_metadata_request(lookup)
+            try:
+                resp = await self.client_stub_v2.ListMetadata(req, **rpc_kwargs)
+            except AioRpcError as exc:
+                raise VSSClientError.from_grpc_error(exc) from exc
+            if not resp.metadata:
+                raise VSSClientError(
+                    error={
+                        "code": grpc.StatusCode.NOT_FOUND.value[0],
+                        "reason": grpc.StatusCode.NOT_FOUND.value[1],
+                        "message": f"Path {path} not found on server",
+                    },
+                    errors=[],
+                )
+            expanded.extend(m.path for m in resp.metadata)
+        return list(dict.fromkeys(expanded))
 
     async def ensure_id_mapping(self, paths: Iterable[str], **rpc_kwargs):
         for path in paths:

--- a/kuksa-client/tests/test_grpc.py
+++ b/kuksa-client/tests/test_grpc.py
@@ -670,6 +670,68 @@ class TestVSSClient:
             'Vehicle.Chassis.Height': Datapoint(666),
         }
 
+    async def test_subscribe_current_values_branch_path_expansion(
+        self, mocker, unused_tcp_port,
+    ):
+        """Branch path (e.g. 'Vehicle') is rejected by v2 Subscribe with
+        NOT_FOUND; client falls back to ListMetadata expansion and retries
+        with the resulting leaf signals (restores pre-0.5.1 semantics for
+        issue #53)."""
+        client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
+
+        not_found = VSSClientError(
+            error={
+                "code": grpc.StatusCode.NOT_FOUND.value[0],
+                "reason": grpc.StatusCode.NOT_FOUND.value[1],
+                "message": "Path not found",
+            },
+            errors=[],
+        )
+
+        call_count = {"v2_subscribe": 0}
+
+        async def v2_subscribe_side_effect(paths, **kwargs):
+            call_count["v2_subscribe"] += 1
+            if call_count["v2_subscribe"] == 1:
+                # First call with branch path — server rejects
+                raise not_found
+            # Second call with expanded leaves — yield real data
+            yield [
+                EntryUpdate(DataEntry(
+                    'Vehicle.Speed', value=Datapoint(42.0),
+                ), (Field.VALUE,)),
+                EntryUpdate(DataEntry(
+                    'Vehicle.ADAS.ABS.IsActive', value=Datapoint(True),
+                ), (Field.VALUE,)),
+            ]
+        mocker.patch.object(
+            client, 'v2_subscribe', side_effect=v2_subscribe_side_effect,
+        )
+
+        async def expand_side_effect(paths, **kwargs):
+            # Simulate ListMetadata resolving 'Vehicle' to two concrete leaves
+            assert list(paths) == ['Vehicle']
+            return ['Vehicle.Speed', 'Vehicle.ADAS.ABS.IsActive']
+        mocker.patch.object(
+            client, '_expand_v2_branch_paths', side_effect=expand_side_effect,
+        )
+
+        received_updates: Dict[str, Datapoint] = {}
+        async for updates in client.subscribe_current_values(['Vehicle']):
+            received_updates.update(updates)
+
+        assert call_count["v2_subscribe"] == 2
+        # First call used the original branch path; retry used expanded leaves.
+        first_paths = list(client.v2_subscribe.call_args_list[0][1]['paths'])
+        second_paths = list(client.v2_subscribe.call_args_list[1][1]['paths'])
+        assert first_paths == ['Vehicle']
+        assert second_paths == ['Vehicle.Speed', 'Vehicle.ADAS.ABS.IsActive']
+        assert received_updates == {
+            'Vehicle.Speed': Datapoint(42.0),
+            'Vehicle.ADAS.ABS.IsActive': Datapoint(True),
+        }
+
     async def test_subscribe_target_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
         client.connected = True  # To bypass connection check


### PR DESCRIPTION
 ## What

  Restores branch-path support in `subscribe_current_values` on the v2 code path.
  Since 0.5.1 preferred v2, calls like `client.subscribe_current_values(['Vehicle'])`
  fail with `NOT_FOUND`: the v2 `Subscribe` RPC only accepts fully-qualified leaf
  paths. v1 Subscribe accepted branch paths natively, so this is a regression for
  existing users.

  Fixes #53.

  ## How

  - On the v2 path, catch `NOT_FOUND` from the first `Subscribe` attempt.
  - Expand the input paths via `ListMetadata(root=path)` — the v2-native way to
    enumerate signals under a branch — and retry `Subscribe` with the resulting
    leaves.
  - Leaf paths stay on the fast path: they never trigger the retry, so no extra
    RPC in the common case.
  - Trailing `.*` (e.g. `Vehicle.Cabin.*`) is stripped before lookup so both the
    v1 idiom `['Vehicle']` and the explicit wildcard form work.
  - The existing `UNIMPLEMENTED` → v1 fallback is preserved for old databrokers.

  ## Scope

  Strictly `subscribe_current_values` (sync + async). `subscribe_target_values`
  has the same shape but is out of scope here — happy to file a symmetric fix in
  a follow-up if the approach looks right.

  ## Existing behavior audit

  - `v2_subscribe` implementation: `kuksa-client/kuksa_client/grpc/aio.py:537` —
    passes `paths` directly into `SubscribeRequest`; no client-side expansion.
  - `_prepare_v2_list_metadata_request`: `kuksa-client/kuksa_client/grpc/__init__.py:907`
    already builds the `ListMetadata` request shape. Reused here.
  - `val.proto` semantics for `ListMetadata`: *"Shall correspond to a VSS branch,
    e.g. `Vehicle`, `Vehicle.Cabin`. Metadata for all signals under that branch
    will be returned."*  (`kuksa/val/v2/val.proto`)
  - v1 `get_metadata` still works with wildcards (per the issue reporter) — which
    is why this is a clear regression from the v2 switch, not a missing feature.

  ## Prior art / related

  - #53 — original bug report (psch0rr)
  - #41 — Schildt's v2 migration timeline issue (establishes v2 as strategic direction)
  - #50 — Extend `subscribe_target_values` to use v2 API (BjoernAtBosch, merged)
  - #49 — Fix `set_current_values` using `kuksa.val.v2` API (BjoernAtBosch, merged)

  ## Tests

  - `test_subscribe_current_values` — unchanged, still passing (leaf-path fast path)
  - `test_subscribe_current_values_branch_path_expansion` — new; asserts that on
    NOT_FOUND the client retries `v2_subscribe` with expanded leaves
  - Full suite: 274/274 pass locally

  ## Not tested (would appreciate reviewer input)

  - Integration against a live databroker v0.6.0 — done by reporter per issue;
    happy to add an integration test if the project has a pattern for that.