### PR TITLE
fix: replace deprecated license classifier with SPDX expression (#46)

### DIFF
--- a/kuksa-client/pyproject.toml
+++ b/kuksa-client/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     # Make sure to use the same exact version criteria in setup.cfg and update requirements.txt after changing
     "grpcio-tools==1.68.0",
-    "setuptools>=42",
+    "setuptools>=77",
     "setuptools-git-versioning",
     "wheel",
 ]

--- a/kuksa-client/setup.cfg
+++ b/kuksa-client/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
+license = Apache-2.0
 name = kuksa_client
 author = Eclipse KUKSA Project
 author_email = kuksa-dev@eclipse.org
@@ -14,7 +15,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Programming Language :: Python :: 3
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Topic :: Software Development
 


### PR DESCRIPTION
Fixes #46.

Per @SebastianSchildt (#46): *"Feel free to give fixing this a try. If this can be done in a contained way, and changing the config + bumping setuptools does the trick without bad side effects, I am all for it."*

### Problem
`setuptools` deprecated the `License ::` trove classifiers in favour of a SPDX license expression, so the build emits:
> `SetuptoolsDeprecationWarning: License classifiers are deprecated. Please consider removing the following classifiers in favor of a SPDX license expression`

### Fix (contained, 2 lines)
- `kuksa-client/setup.cfg` — drop the `License :: OSI Approved :: Apache Software License` classifier; add `license = Apache-2.0` (SPDX expression) under `[metadata]`.
- `kuksa-client/pyproject.toml` — bump the build requirement `setuptools>=42` → `setuptools>=77`. PEP 639 SPDX-expression support landed in setuptools 77; without the bump an older setuptools would treat `Apache-2.0` as free-text and the warning wouldn't clear.

`license_files = LICENSE` is unchanged.

### Verification (no bad side effects)
Built sdist + wheel with setuptools 82 (`python -m build`):
- **Before:** `SetuptoolsDeprecationWarning: License classifiers are deprecated` present.
- **After:** warning gone (0 occurrences); build exits 0; both artifacts produced.
- Wheel `METADATA` (Metadata-Version 2.4): `License: Apache-2.0`, `License-File: LICENSE`, and **no** `Classifier: License ::` line remaining.
