### PR TITLE
KUKSA 0.5.2 patch release prep

### DIFF
--- a/kuksa-client/requirements.txt
+++ b/kuksa-client/requirements.txt
@@ -4,29 +4,31 @@
 #
 #    pip-compile setup.cfg
 #
-attrs==24.2.0
+attrs==26.1.0
     # via cmd2
 cmd2==1.5.0
     # via kuksa_client (setup.cfg)
 colorama==0.4.6
     # via cmd2
-grpcio==1.68.0
+grpcio==1.82.1
     # via grpcio-tools
 grpcio-tools==1.68.0
     # via kuksa_client (setup.cfg)
-jsonpath-ng==1.7.0
+jsonpath-ng==1.8.0
     # via kuksa_client (setup.cfg)
-ply==3.11
-    # via jsonpath-ng
 protobuf==5.29.6
-    # via grpcio-tools
+    # via
+    #   grpcio-tools
+    #   kuksa_client (setup.cfg)
 pygments==2.20.0
     # via kuksa_client (setup.cfg)
-pyperclip==1.9.0
+pyperclip==1.11.0
     # via cmd2
-wcwidth==0.2.13
+typing-extensions==4.16.0
+    # via grpcio
+wcwidth==0.8.2
     # via cmd2
-websockets==14.1
+websockets==16.1
     # via kuksa_client (setup.cfg)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/kuksa-client/test-requirements.txt
+++ b/kuksa-client/test-requirements.txt
@@ -4,75 +4,85 @@
 #
 #    pip-compile --extra=test --output-file=test-requirements.txt setup.cfg
 #
-astroid==3.3.5
+astroid==4.0.4
     # via pylint
-attrs==24.2.0
+attrs==26.1.0
     # via cmd2
+backports-asyncio-runner==1.2.0; python_version < "3.11"
+    # via pytest-asyncio
 cmd2==1.5.0
     # via kuksa_client (setup.cfg)
 colorama==0.4.6
     # via cmd2
-coverage[toml]==7.6.7
+coverage[toml]==7.15.2
     # via pytest-cov
-dill==0.3.9
+dill==0.4.1
     # via pylint
-exceptiongroup==1.2.2
+exceptiongroup==1.3.1
     # via pytest
-grpcio==1.68.0
+grpcio==1.82.1
     # via grpcio-tools
 grpcio-tools==1.68.0
     # via kuksa_client (setup.cfg)
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
-isort==5.13.2
+isort==8.0.1
     # via pylint
-jsonpath-ng==1.7.0
+jsonpath-ng==1.8.0
     # via kuksa_client (setup.cfg)
 mccabe==0.7.0
     # via pylint
-packaging==24.2
+packaging==26.2
     # via pytest
-platformdirs==4.3.6
+platformdirs==4.10.0
     # via pylint
-pluggy==1.5.0
-    # via pytest
-ply==3.11
-    # via jsonpath-ng
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
 protobuf==5.29.6
-    # via grpcio-tools
+    # via
+    #   grpcio-tools
+    #   kuksa_client (setup.cfg)
 pygments==2.20.0
+    # via
+    #   kuksa_client (setup.cfg)
+    #   pytest
+pylint==4.0.6
     # via kuksa_client (setup.cfg)
-pylint==3.3.1
-    # via kuksa_client (setup.cfg)
-pyperclip==1.9.0
+pyperclip==1.11.0
     # via cmd2
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   kuksa_client (setup.cfg)
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
     #   pytest-timeout
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via kuksa_client (setup.cfg)
-pytest-cov==6.0.0
+pytest-cov==7.1.0
     # via kuksa_client (setup.cfg)
-pytest-mock==3.14.0
+pytest-mock==3.15.1
     # via kuksa_client (setup.cfg)
-pytest-timeout==2.3.1
+pytest-timeout==2.4.0
     # via kuksa_client (setup.cfg)
-tomli==2.1.0
+tomli==2.4.1
     # via
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.13.2
+tomlkit==0.15.1
     # via pylint
-typing-extensions==4.12.2
-    # via astroid
-wcwidth==0.2.13
+typing-extensions==4.16.0
+    # via
+    #   astroid
+    #   exceptiongroup
+    #   grpcio
+    #   pytest-asyncio
+wcwidth==0.8.2
     # via cmd2
-websockets==14.1
+websockets==16.1
     # via kuksa_client (setup.cfg)
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
As suggested in #54 preparing a patch release

This is a minimum effort release, and thus it keeps some bugs in the CLI client and is not compatible with Python 3.14. This will be addressed in #61 , but as there are some more changes here (that might break things for some people), trying a minimal patch release first that "should work" for anyone that is currently happy with 0.5.1

CI: Ignore the markdown check. This is due to recent changes in databroker, and the broken references will be removed once we remove sdv1 API support from this package as well